### PR TITLE
Refine data deletion page with dark minimalist styling

### DIFF
--- a/wisdom-web/src/DataDeletion.css
+++ b/wisdom-web/src/DataDeletion.css
@@ -1,0 +1,112 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
+body.data-deletion-active {
+  margin: 0;
+  font-family: 'Inter', 'Inter var', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #0b0b0d;
+  min-height: 100vh;
+  display: block;
+  color-scheme: dark;
+  color: #e5e5e5;
+}
+
+.data-deletion-page {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 4rem 1.5rem 5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.data-deletion-header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  text-align: center;
+}
+
+.data-deletion-header h1 {
+  font-size: clamp(2.25rem, 4vw, 3rem);
+  font-weight: 600;
+  margin: 0;
+  letter-spacing: -0.02em;
+}
+
+.data-deletion-header p {
+  margin: 0;
+  display: flex;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+  color: #b0b0b0;
+  text-transform: none;
+}
+
+.data-deletion-header .label {
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #8c8c8c;
+}
+
+.data-deletion-card {
+  background-color: #121214;
+  border: 1px solid #1f1f1f;
+  border-radius: 12px;
+  padding: 1.75rem;
+  box-shadow: none;
+}
+
+.data-deletion-card h2 {
+  margin: 0 0 1rem;
+  font-size: 1.2rem;
+  font-weight: 500;
+  color: #f0f0f0;
+}
+
+.data-deletion-card p,
+.data-deletion-card li {
+  font-size: 1rem;
+  line-height: 1.6;
+  color: #d4d4d4;
+}
+
+.data-deletion-card ul {
+  margin: 0;
+  padding-left: 1.1rem;
+}
+
+.data-deletion-card a {
+  color: #f5f5f5;
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.data-deletion-card a:hover,
+.data-deletion-card a:focus {
+  text-decoration: underline;
+}
+
+.data-deletion-footer {
+  margin-top: 1rem;
+  text-align: center;
+  font-size: 0.9rem;
+  color: #8c8c8c;
+}
+
+@media (max-width: 640px) {
+  .data-deletion-page {
+    padding: 3rem 1rem 3.5rem;
+  }
+
+  .data-deletion-card {
+    padding: 1.5rem;
+  }
+
+  .data-deletion-header p {
+    flex-direction: column;
+    align-items: center;
+    gap: 0.25rem;
+  }
+}

--- a/wisdom-web/src/DataDeletion.jsx
+++ b/wisdom-web/src/DataDeletion.jsx
@@ -1,0 +1,67 @@
+import { useEffect } from 'react';
+import './DataDeletion.css';
+
+export default function DataDeletion() {
+  useEffect(() => {
+    document.title = 'Wisdom – Data Deletion Request';
+  }, []);
+
+  useEffect(() => {
+    document.body.classList.add('data-deletion-active');
+    return () => {
+      document.body.classList.remove('data-deletion-active');
+    };
+  }, []);
+
+  return (
+    <main className="data-deletion-page">
+      <header className="data-deletion-header">
+        <h1>Wisdom – Data Deletion Request</h1>
+        <p>
+          <span className="label">Developer</span>
+          <span>Oier Hernanz Arroyo</span>
+        </p>
+        <p>
+          <span className="label">App</span>
+          <span>Wisdom (com.anonymous.Wisdom_expo)</span>
+        </p>
+      </header>
+
+      <section className="data-deletion-card">
+        <h2>How to request deletion</h2>
+        <p>
+          Email{' '}
+          <a href="mailto:wisdom.helpcontact@gmail.com">wisdom.helpcontact@gmail.com</a> from the address linked to your account. Tell us whether you need a partial deletion (services, chats, addresses, images) or a full account removal. We process every request within 30 days and confirm completion by email.
+        </p>
+      </section>
+
+      <section className="data-deletion-card">
+        <h2>What we delete</h2>
+        <ul>
+          <li>Profile details</li>
+          <li>Saved addresses</li>
+          <li>Services and related images</li>
+          <li>Chats and messages</li>
+          <li>Reviews and ratings</li>
+          <li>Booking history</li>
+        </ul>
+      </section>
+
+      <section className="data-deletion-card">
+        <h2>What we retain and for how long</h2>
+        <p>
+          Payment and billing records (Stripe) and security or fraud logs are retained for up to 90 days to meet legal obligations. After that period they are deleted or anonymized.
+        </p>
+      </section>
+
+      <section className="data-deletion-card">
+        <h2>Security</h2>
+        <p>All data is transmitted over encrypted connections (TLS/HTTPS).</p>
+      </section>
+
+      <footer className="data-deletion-footer">
+        <p>Last updated: {new Date().toLocaleDateString('en-US')}</p>
+      </footer>
+    </main>
+  );
+}

--- a/wisdom-web/src/main.jsx
+++ b/wisdom-web/src/main.jsx
@@ -1,10 +1,19 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import App from './App.jsx'
-import './index.css'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App.jsx';
+import DataDeletion from './DataDeletion.jsx';
+import './index.css';
+
+const normalizePathname = (pathname) => {
+  if (!pathname) return '/';
+  const trimmed = pathname.endsWith('/') && pathname !== '/' ? pathname.slice(0, -1) : pathname;
+  return trimmed || '/';
+};
+
+const currentPath = normalizePathname(window.location.pathname);
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    {currentPath === '/data-deletion' ? <DataDeletion /> : <App />}
   </StrictMode>,
-)
+);


### PR DESCRIPTION
## Summary
- translate the data deletion page content to English and update the document title
- restyle the layout with an Inter-based dark grayscale palette and centered heading
- simplify card presentation with minimalist panels while preserving required data-retention messaging

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f284da2a48832b83c731cc4f18af85