### PR TITLE
feat: recreate landing page with mockup sections

### DIFF
--- a/wisdom-web/package-lock.json
+++ b/wisdom-web/package-lock.json
@@ -11,7 +11,8 @@
         "framer-motion": "^11.11.8",
         "qrcode.react": "^4.0.1",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "three": "^0.181.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.11.1",
@@ -5140,6 +5141,12 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/three": {
+      "version": "0.181.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.181.1.tgz",
+      "integrity": "sha512-bz9xZUQMw3pJbjKy7roiwXWgAp+oVUa+4k5o0oBAQ+IFJuru1xzvtk63h6k72XZanXS/SgoEhV6927Vgazyq2w==",
+      "license": "MIT"
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",

--- a/wisdom-web/package.json
+++ b/wisdom-web/package.json
@@ -13,7 +13,8 @@
     "framer-motion": "^11.11.8",
     "qrcode.react": "^4.0.1",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "three": "^0.181.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.11.1",

--- a/wisdom-web/postcss.config.cjs
+++ b/wisdom-web/postcss.config.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};
+

--- a/wisdom-web/src/App.css
+++ b/wisdom-web/src/App.css
@@ -1,10 +1,14 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
+/* Tu CSS a mano, debajo */
 .container {
-  position: fixed; /* Cambia a absolute para llenar toda la ventana */
-  top: 0;            /* Asegúrate de que empiece en la parte superior */
-  left: 0;           /* Asegúrate de que empiece en la izquierda */
-  width: 100%;       /* Ocupa el 100% del ancho del viewport */
-  height: 100%;      /* Ocupa el 100% de la altura del viewport */
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
   overflow: hidden;
   background-color: black;
 }

--- a/wisdom-web/src/App.jsx
+++ b/wisdom-web/src/App.jsx
@@ -191,7 +191,7 @@ function App() {
             </nav>
             <div className="flex items-center space-x-4 text-sm font-semibold">
               <button type="button" className="text-slate-800">Login</button>
-              <button type="button" className="rounded-full bg-slate-900 px-5 py-2 text-white shadow-lg">Sign up</button>
+              <button type="button" className="rounded-full bg-slate-900 px-5 py-2 text-red-500 shadow-lg">Sign up</button>
             </div>
           </header>
           <div className="text-center pt-16">

--- a/wisdom-web/src/App.jsx
+++ b/wisdom-web/src/App.jsx
@@ -1,274 +1,469 @@
+import { useMemo, useState } from 'react';
+import SkyStars from './components/SkyStars';
 
+const navLinks = ['Use cases', 'Features', 'Pricing', 'Our doctors'];
 
-import { useState, useEffect } from 'react';
-import './App.css';
-
-import WisdomLogo from './assets/wisdomLogo.tsx';
-import appleLogo from './assets/appleLogo.png';
-import androidLogo from './assets/androidLogo.png';
-import qrRandom from './assets/qrTR.png';
-
-const categoriesArray = [
-  { id: 2, category: "Plumbing", url: "https://storage.googleapis.com/wisdom-images/Captura%20de%20pantalla%202024-09-27%20174847.png" },
-  { id: 89, category: "AI development", url: "https://storage.googleapis.com/wisdom-images/Captura%20de%20pantalla%202024-09-27%20201215.png" },
-  { id: 1, category: "Home cleaning", url: "https://storage.googleapis.com/wisdom-images/Captura%20de%20pantalla%202024-09-27%20174733.png" },
-  { id: 31, category: "Personal trainers", url: "https://storage.googleapis.com/wisdom-images/Captura%20de%20pantalla%202024-09-27%20175621.png" },
-  { id: 317, category: "Dog walkers", url: "https://storage.googleapis.com/wisdom-images/Captura%20de%20pantalla%202024-09-27%20190223.png" },
-  { id: 318, category: "Pet care at home", url: "https://storage.googleapis.com/wisdom-images/Captura%20de%20pantalla%202024-09-27%20190446.png" },
-  { id: 5, category: "Masonry", url: "https://storage.googleapis.com/wisdom-images/Captura%20de%20pantalla%202024-09-27%20175117.png" },
-  { id: 83, category: "Mobile app development", url: "https://storage.googleapis.com/wisdom-images/451067aa-4bd3-43d8-874d-ff8b5e50ce7e.jpeg" },
-  { id: 151, category: "Architects", url: "https://storage.googleapis.com/wisdom-images/526bda5b-c0c2-4170-b552-12a17db69fa9.jpeg" },
-  { id: 8, category: "Painting and decoration", url: "https://storage.googleapis.com/wisdom-images/237ee01c-4454-4d81-8f27-f502f74ac9d3.jpeg" },
-  { id: 3, category: "Electrical work", url: "https://storage.googleapis.com/wisdom-images/Captura%20de%20pantalla%202024-09-27%20175034.png" },
-  { id: 6, category: "Gardening", url: "https://storage.googleapis.com/wisdom-images/4a4881ba-a06f-4bb1-be9d-016d2b49eae4.jpeg" },
-  { id: 32, category: "Nutritionists", url: "https://storage.googleapis.com/wisdom-images/Captura%20de%20pantalla%202024-09-27%20175812.png" },
-  { id: 34, category: "Psychology", url: "https://storage.googleapis.com/wisdom-images/Captura%20de%20pantalla%202024-09-27%20180032.png" },
-  { id: 35, category: "Yoga", url: "https://storage.googleapis.com/wisdom-images/Captura%20de%20pantalla%202024-09-27%20180113.png" },
-  { id: 36, category: "Guided meditation", url: "https://storage.googleapis.com/wisdom-images/53a50b05-32d7-4e90-86ce-62702bc97d65.jpeg" },
-  { id: 37, category: "Therapeutic massages", url: "https://storage.googleapis.com/wisdom-images/Captura%20de%20pantalla%202024-09-27%20180612.png" },
-  { id: 54, category: "Couples therapy", url: "https://storage.googleapis.com/wisdom-images/Captura%20de%20pantalla%202024-09-27%20180656.png" },
-  { id: 56, category: "Private tutors", url: "https://storage.googleapis.com/wisdom-images/77502ab75202d6b38aa0df57113b6746.jpg" },
-  { id: 57, category: "Math classes", url: "https://storage.googleapis.com/wisdom-images/Captura%20de%20pantalla%202024-09-27%20180933.png" },
-  { id: 58, category: "Language classes", url: "https://storage.googleapis.com/wisdom-images/6f1a64adbbe28f7d572a9fef189ea542.jpg" },
-  { id: 59, category: "Science classes", url: "https://storage.googleapis.com/wisdom-images/Captura%20de%20pantalla%202024-09-27%20181138.png" },
-  { id: 68, category: "Job interview preparation", url: "https://storage.googleapis.com/wisdom-images/36548671ef1476a260d9e3dbb8fe4706.jpg" },
-  { id: 65, category: "Music classes", url: "https://storage.googleapis.com/wisdom-images/Captura%20de%20pantalla%202024-09-27%20181310.png" },
-  { id: 61, category: "Programming classes", url: "https://storage.googleapis.com/wisdom-images/Captura%20de%20pantalla%202024-09-27%20181628.png" },
-  { id: 85, category: "Frontend development", url: "https://storage.googleapis.com/wisdom-images/Captura%20de%20pantalla%202024-09-27%20182501.png" },
-  { id: 86, category: "Backend development", url: "https://storage.googleapis.com/wisdom-images/Captura%20de%20pantalla%202024-09-27%20182034.png" },
-  { id: 90, category: "Graphic design", url: "https://storage.googleapis.com/wisdom-images/a2b2c958-2d21-4308-8b07-51a1820f6faa.jpeg" },
-  { id: 94, category: "Video editing", url: "https://storage.googleapis.com/wisdom-images/ad3a9403cb4273ff3bfb2ab24429bb62.jpg" },
-  { id: 100, category: "3D design", url: "https://storage.googleapis.com/wisdom-images/4475f6e7e9766c27834ae79e308907db2d4fe361f741e26a2e9357b0a6c63082_1920x1080.webp" },
-  { id: 101, category: "Social media content creation", url: "https://storage.googleapis.com/wisdom-images/contentcretor.png" },
-  { id: 152, category: "Masons", url: "https://storage.googleapis.com/wisdom-images/Captura%20de%20pantalla%202024-09-27%20175117.png" },
-  { id: 170, category: "Building rehabilitation", url: "https://storage.googleapis.com/wisdom-images/5964b65c-a2f6-4638-9024-6b38b2e0f42a.jpeg" },
-  { id: 172, category: "Wedding planners", url: "https://storage.googleapis.com/wisdom-images/Captura%20de%20pantalla%202024-09-27%20184608.png" },
-  { id: 173, category: "Event Catering", url: "https://storage.googleapis.com/wisdom-images/Captura%20de%20pantalla%202024-09-27%20184635.png" },
-  { id: 174, category: "Event photography", url: "https://storage.googleapis.com/wisdom-images/Captura%20de%20pantalla%202024-09-27%20184808.png" },
-  { id: 175, category: "Party DJs", url: "https://storage.googleapis.com/wisdom-images/Captura%20de%20pantalla%202024-09-27%20184853.png" },
-  { id: 178, category: "Children's entertainers", url: "https://storage.googleapis.com/wisdom-images/1.webp" },
-  { id: 181, category: "Event security", url: "https://storage.googleapis.com/wisdom-images/Captura%20de%20pantalla%202024-09-27%20185110.png" },
-  { id: 228, category: "Business analysis", url: "https://storage.googleapis.com/wisdom-images/Captura%20de%20pantalla%202024-09-27%20190143.png" },
+const saveCards = [
+  {
+    title: 'Letters',
+    subtitle: 'Instantly generate personalised medical letters',
+    description:
+      'Upload patient letters, consultations or prompts and choose the exact document you need in seconds.',
+    actions: ['Upload past letters', 'Choose documents', 'Type it in'],
+    accent: '#f8f2ff',
+  },
+  {
+    title: 'Transcribe',
+    subtitle: 'Transcribe dictations, consultations & telehealth',
+    description:
+      'Turn minutes into text with clinically accurate transcriptions that fit straight into your workflow.',
+    actions: ['Upload consultations', 'Choose audio', 'Drop recordings'],
+    accent: '#eef8ff',
+  },
 ];
 
+const workflowTabs = {
+  letters: {
+    title: 'Letters',
+    description: 'Personalise every letter with templates that learn from your style.',
+    steps: [
+      'Select a tone that mirrors your past letters.',
+      'Drop in prompts, dictations or forms to prefill.',
+      'Generate a gold-standard draft ready for sign-off.',
+    ],
+  },
+  transcribe: {
+    title: 'Transcribe',
+    description: 'Upload any recording for fast, accurate transcripts.',
+    steps: [
+      'Choose the appointment, consult or meeting file.',
+      'Our dictionary catches every speciality-specific detail.',
+      'Export straight into your clinical system.',
+    ],
+  },
+};
+
+const writingCards = [
+  {
+    title: 'Generate personalised letters that sound like you',
+    description:
+      'Let us learn your style based on past letters and create a template that sounds exactly like you.',
+    accent: '#f3f5ff',
+  },
+  {
+    title: 'Upload any source to create your letter',
+    description:
+      'Add text, upload files or scans, consultations, recordings — we will turn it all into a refined letter.',
+    accent: '#fff8f0',
+  },
+];
+
+const practiceSteps = [
+  {
+    title: 'Invite your practice to Letters',
+    description:
+      'Easily get started by inviting your team — including doctors, allied health professionals and admin staff.',
+  },
+  {
+    title: 'Seamlessly onboard your practice',
+    description:
+      'Our intuitive platform means your practice is up and running in days, helped by helpful scripts and clear actions.',
+  },
+  {
+    title: "See your team's impact",
+    description:
+      'Letters keeps your clinicians focused while dashboards show the time saved by each person, week after week.',
+  },
+];
+
+const testimonials = [
+  {
+    name: 'Dr. Ram Neshwani',
+    role: 'The Cardiology Dentists',
+    quote:
+      'We set up Letters in our surgery for all our dentists — we have 5 surgeries and the difference is huge. The support is like nothing else, highly recommend Letters.',
+  },
+  {
+    name: 'Grace MacPherson',
+    role: 'Practice Manager',
+    quote:
+      'As a Practice Manager, Letters has transformed the way our doctors maintain accuracy of patient files. The reduction in admin time has been immediate.',
+  },
+  {
+    name: 'Dr. David Lenz',
+    role: 'Oral Health Surgeon',
+    quote:
+      'It picks up every detail. It is so quick that I use it daily, even for missed dictations and follow ups.',
+  },
+];
+
+const securityHighlights = [
+  {
+    title: 'Secure with bank-grade protection',
+    description: 'Letters complies with Australian privacy regulations, including the Australian Privacy Act 1988.',
+  },
+  {
+    title: 'Your data never leaves Australia',
+    description: 'All data is processed and stored exclusively on secure servers located in Sydney.',
+  },
+  {
+    title: 'Recordings & files are never stored',
+    description: 'We delete audio & files instantly once processed. Your conversations remain private forever.',
+  },
+];
+
+const pricingPlans = [
+  {
+    name: 'Letters Basic',
+    price: 'Free',
+    description: 'For solo use with light needs.',
+    features: ['Unlimited letters', '3/day transcriptions', '1 personalised template'],
+    cta: 'Start for Free',
+  },
+  {
+    name: 'Letters Pro',
+    price: '$66/mo',
+    description: 'For busy doctors & growing practices.',
+    features: ['Unlimited letters', 'Consultations', 'Assistant', 'Practice tools'],
+    cta: 'Start a 2-Week Trial',
+  },
+  {
+    name: 'Letters Enterprise',
+    price: 'Flexible',
+    description: 'For practices, clinics and beyond.',
+    features: ['Custom pricing', 'Dedicated support', 'Deployment options'],
+    cta: 'Contact Sales',
+  },
+];
+
+const deviceCards = [
+  {
+    title: 'iPhone & Android',
+    description: 'Dictate from your phone anywhere and the transcript appears instantly on desktop.',
+  },
+  {
+    title: 'Web App',
+    description: 'Craft letters, edit transcripts and collaborate with your team in real time.',
+  },
+  {
+    title: 'Tablet ready',
+    description: 'Pick up on iPad to sign off documents with the same clean workspace.',
+  },
+];
+
+const SectionWrapper = ({ children, className = '' }) => (
+  <section className={`py-20 px-6 ${className}`}>
+    <div className="max-w-6xl mx-auto">{children}</div>
+  </section>
+);
+
 function App() {
-  const [activeImages, setActiveImages] = useState([]);
-  const [currentBackgroundImages, setCurrentBackgroundImages] = useState([]);
-  const [isWindowActive, setIsWindowActive] = useState(true);
+  const [activeWorkflow, setActiveWorkflow] = useState('letters');
+  const [billingCycle, setBillingCycle] = useState('annual');
 
-  useEffect(() => {
-    const handleVisibilityChange = () => {
-      setIsWindowActive(!document.hidden);
-    };
-
-    document.addEventListener("visibilitychange", handleVisibilityChange);
-
-    return () => {
-      document.removeEventListener("visibilitychange", handleVisibilityChange);
-    };
-  }, []);
-
-  useEffect(() => {
-    const addRandomImage = () => {
-      if (!isWindowActive) return; // Stop adding images when the window is inactive
-
-      const randomImage = categoriesArray[Math.floor(Math.random() * categoriesArray.length)];
-      if (activeImages.length >= 10) return;
-
-      const newImage = {
-        ...randomImage,
-        id: Math.random(),
-        left: window.innerWidth,
-        top: Math.random() * (window.innerHeight - 100),
-      };
-
-      setActiveImages((prev) => [...prev, newImage]);
-
-      setTimeout(() => {
-        setActiveImages((prev) => prev.filter((img) => img.left > -300));
-      }, Math.random() * 8000 + 5000);
-    };
-
-    addRandomImage();
-
-    const addImageInterval = setInterval(() => {
-      addRandomImage();
-    }, Math.random() * 8000 + 8000);
-
-    return () => clearInterval(addImageInterval);
-  }, [isWindowActive]);
-
-  useEffect(() => {
-    const addRandomBackgroundImage = () => {
-      if (!isWindowActive) return; // Stop adding background images when the window is inactive
-
-      const randomImage = categoriesArray[Math.floor(Math.random() * categoriesArray.length)];
-      if (currentBackgroundImages.length >= 5) return;
-
-      const newImage = {
-        ...randomImage,
-        id: Math.random(),
-        left: window.innerWidth,
-        top: Math.random() * (window.innerHeight - 100),
-      };
-
-      setCurrentBackgroundImages((prev) => [...prev, newImage]);
-
-      setTimeout(() => {
-        setCurrentBackgroundImages((prev) => prev.filter((img) => img.left > -300));
-      }, Math.random() * 10000 + 5000);
-    };
-
-    addRandomBackgroundImage();
-
-    const addBackgroundImageInterval = setInterval(() => {
-      addRandomBackgroundImage();
-    }, Math.random() * 13000 + 10000);
-
-    return () => clearInterval(addBackgroundImageInterval);
-  }, [isWindowActive]);
-
-  useEffect(() => {
-    const moveImages = () => {
-      if (!isWindowActive) return; // Stop moving images when the window is inactive
-
-      setActiveImages((prev) =>
-        prev.map((img) => ({
-          ...img,
-          left: img.left - 0.6,
-        }))
-      );
-    };
-
-    const moveBackgroundImages = () => {
-      if (!isWindowActive) return; // Stop moving background images when the window is inactive
-
-      setCurrentBackgroundImages((prev) =>
-        prev.map((img) => ({
-          ...img,
-          left: img.left - 0.3,
-        }))
-      );
-    };
-
-    const moveInterval = setInterval(() => {
-      moveImages();
-      moveBackgroundImages();
-    }, 10);
-
-    return () => clearInterval(moveInterval);
-  }, [isWindowActive, activeImages, currentBackgroundImages]);
-
-  const handleAppleClick = () => {
-    window.location.href = "https://testflight.apple.com/join/cyXuf7w4";
-  };
-
-  const handleAndroidClick = () => {
-    window.location.href = "https://play.google.com/store/apps/details?id=com.anonymous.Wisdom_expo";
-  };
-
-  const handleQrClick = () => {
-    window.location.href = "https://drive.google.com/file/d/1vztIvrMEzE1c3RMZrOoBs9dbK12K-1JT/view?usp=drive_link";
-  };
+  const workflowContent = workflowTabs[activeWorkflow];
+  const billingTag = useMemo(
+    () => (billingCycle === 'annual' ? 'Save 18%/yr' : 'Pay monthly'),
+    [billingCycle],
+  );
 
   return (
-    <div className="container flex-1">
-      {currentBackgroundImages.map((image) => (
-        <img
-          key={image.id}
-          src={image.url}
-          alt={image.category}
-          className="background-image"
-          style={{
-            left: `${image.left}px`,
-            top: `${image.top}px`,
-            position: 'absolute',
-            transition: 'none',
-            width: '200px',
-            height: '100px',
-            objectFit: 'cover',
-            opacity: 0.7,
-            filter: 'blur(2px)',
-            borderRadius: '8px',
-          }}
-        />
-      ))}
-
-      {activeImages.map((image) => (
-        <img
-          key={image.id}
-          src={image.url}
-          alt={image.category}
-          className="moving-image"
-          style={{
-            left: `${image.left}px`,
-            top: `${image.top}px`,
-            position: 'absolute',
-            transition: 'none',
-            width: '330px',
-            height: '150px',
-            objectFit: 'cover',
-            borderRadius: '15px',
-          }}
-        />
-      ))}
-
-      <div className="centered-container">
-        <WisdomLogo className="logo" color="#ffffff" />
-         <h1 style={{ fontSize: 'min(5vw, 25px)', marginBottom: 40, marginTop: 10, color: '#bdbdbd' }}>Wisdom</h1>
-        <div className="qr-container">
-          <img
-            src={qrRandom}
-            alt="QR Code"
-            onClick={handleQrClick}
-            className="qr-code"
-          />
-          <div
-            style={{
-              height: '0.25rem',
-              width: '100%',
-              marginTop: '0.25rem',
-              marginBottom: '1rem',
-              borderBottom: '2px solid #323635',
-            }}
-          />
-          <div
-            style={{
-              display: 'flex',
-              justifyContent: 'center',
-              alignItems: 'center',
-              gap: 'min(20vw, 100px)',
-            }}
-          >
-            <img
-              src={appleLogo}
-              alt="Apple Store"
-              onClick={handleAppleClick}
-              className="store-logo"
-            />
-            <img
-              src={androidLogo}
-              alt="Android Store"
-              onClick={handleAndroidClick}
-              className="store-logo"
-            />
+    <div className="min-h-screen bg-[#f7f7f7] text-slate-900 font-inter">
+      <section className="relative overflow-hidden rounded-b-[56px] bg-gradient-to-b from-[#9ec4ff] via-[#cfe1ff] to-[#f8fbff] pb-32">
+        <div className="absolute inset-0 opacity-80">
+          <SkyStars />
+        </div>
+        <div className="absolute inset-x-0 bottom-0 h-48 bg-gradient-to-t from-white to-transparent" />
+        <div className="relative z-10 max-w-6xl mx-auto px-6">
+          <header className="flex items-center justify-between py-8">
+            <div className="flex items-center space-x-2">
+              <div className="h-9 w-9 rounded-2xl bg-white/80 flex items-center justify-center text-xl font-semibold text-blue-500">
+                L
+              </div>
+              <span className="text-lg font-semibold text-slate-900">Letters</span>
+            </div>
+            <nav className="hidden md:flex items-center space-x-8 text-sm font-medium text-slate-800">
+              {navLinks.map((link) => (
+                <button type="button" key={link} className="hover:text-blue-700 transition-colors">
+                  {link}
+                </button>
+              ))}
+            </nav>
+            <div className="flex items-center space-x-4 text-sm font-semibold">
+              <button type="button" className="text-slate-800">Login</button>
+              <button type="button" className="rounded-full bg-slate-900 px-5 py-2 text-white shadow-lg">Sign up</button>
+            </div>
+          </header>
+          <div className="text-center pt-16">
+            <p className="text-sm uppercase tracking-[0.3em] text-slate-700">Use cases</p>
+            <h1 className="mt-6 text-4xl md:text-6xl font-semibold text-slate-900">Patients, not paperwork</h1>
+            <p className="mt-4 text-lg text-slate-700 max-w-2xl mx-auto">
+              Write letters instantly that sound like you. Enjoy unlimited, gold-standard transcriptions. Save 5+ hours weekly on paperwork.
+            </p>
+            <button
+              type="button"
+              className="mt-8 rounded-full bg-slate-900 px-8 py-3 text-white text-sm font-semibold shadow-2xl"
+            >
+              Sign up for free
+            </button>
+          </div>
+          <div className="mt-16 flex justify-center">
+            <div className="w-full max-w-3xl rounded-[36px] bg-white/90 shadow-[0_40px_120px_rgba(15,23,42,0.15)] p-8">
+              <div className="flex flex-col md:flex-row items-start gap-8">
+                <div className="flex-1">
+                  <div className="inline-flex items-center rounded-full bg-slate-100 px-4 py-1 text-xs font-semibold uppercase tracking-widest text-slate-600">
+                    Before
+                  </div>
+                  <p className="mt-4 text-slate-600 text-sm leading-relaxed">
+                    Dictate for 12 minutes. Think about formatting, headings, patient tone and double check spelling while toggling between systems.
+                  </p>
+                </div>
+                <div className="flex-1">
+                  <div className="inline-flex items-center rounded-full bg-blue-100 px-4 py-1 text-xs font-semibold uppercase tracking-widest text-blue-600">
+                    After
+                  </div>
+                  <p className="mt-4 text-slate-900 font-semibold">
+                    Use Letters to create gold-standard letters instantly. Upload dictations, choose your template and we deliver the perfect letter ready to send.
+                  </p>
+                </div>
+              </div>
+              <div className="mt-8 h-32 rounded-3xl bg-gradient-to-r from-[#dbeafe] to-[#e0e7ff]" />
+            </div>
           </div>
         </div>
-      </div>
-      
-      <div
-        style={{
-          position: 'absolute',
-          bottom: '20px',
-          left: '50%',
-          transform: 'translateX(-50%)',
-          textAlign: 'center',
-          fontSize: '12px',
-          color: '#474646',
-        }}
-      >
-        Via Europa, 98-2, Mataró, Barcelona • wisdom.helpcontact@gmail.com • +34699187491
-      </div>
+      </section>
+
+      <SectionWrapper>
+        <div className="text-center">
+          <p className="text-sm uppercase tracking-[0.4em] text-slate-500">Save more time</p>
+          <h2 className="mt-4 text-4xl font-semibold">Save <span className="inline-flex items-center">5
+            <span className="ml-2 text-2xl">hours</span>
+          </span> a week with Letters</h2>
+          <p className="mt-4 text-lg text-slate-600">Instantly generate personalised medical letters and transcriptions.</p>
+        </div>
+        <div className="mt-12 grid gap-8 md:grid-cols-2">
+          {saveCards.map((card) => (
+            <div key={card.title} className="rounded-[36px] bg-white p-8 shadow-[0_25px_90px_rgba(15,23,42,0.08)]">
+              <div className="flex items-center justify-between">
+                <div className="text-sm font-semibold text-slate-500">{card.title}</div>
+                <div className="h-10 w-10 rounded-2xl" style={{ backgroundColor: card.accent }} />
+              </div>
+              <h3 className="mt-6 text-2xl font-semibold text-slate-900">{card.subtitle}</h3>
+              <p className="mt-3 text-slate-600">{card.description}</p>
+              <div className="mt-6 space-y-2">
+                {card.actions.map((action) => (
+                  <div key={action} className="flex items-center space-x-3 text-sm text-slate-600">
+                    <span className="h-2 w-2 rounded-full bg-slate-900" />
+                    <span>{action}</span>
+                  </div>
+                ))}
+              </div>
+              <div className="mt-8 h-32 rounded-3xl" style={{ backgroundColor: card.accent }} />
+            </div>
+          ))}
+        </div>
+      </SectionWrapper>
+
+      <SectionWrapper className="pt-6">
+        <div className="text-center">
+          <p className="text-sm uppercase tracking-[0.4em] text-slate-500">Product tour</p>
+          <h2 className="mt-4 text-4xl font-semibold">How <span className="text-blue-600">Letters</span> works</h2>
+        </div>
+        <div className="mt-8 flex justify-center gap-4">
+          {Object.keys(workflowTabs).map((key) => (
+            <button
+              type="button"
+              key={key}
+              onClick={() => setActiveWorkflow(key)}
+              className={`rounded-full px-6 py-2 text-sm font-semibold shadow ${
+                activeWorkflow === key ? 'bg-slate-900 text-white shadow-lg' : 'bg-white text-slate-600'
+              }`}
+            >
+              {workflowTabs[key].title}
+            </button>
+          ))}
+        </div>
+        <div className="mt-10 grid gap-10 lg:grid-cols-[1fr_1.2fr] items-center">
+          <div>
+            <p className="text-lg font-semibold text-slate-900">{workflowContent.title}</p>
+            <p className="mt-4 text-slate-600">{workflowContent.description}</p>
+            <ul className="mt-6 space-y-4 text-slate-600">
+              {workflowContent.steps.map((step) => (
+                <li key={step} className="flex items-start space-x-3">
+                  <span className="mt-1 h-2.5 w-2.5 rounded-full bg-blue-500" />
+                  <span>{step}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div className="rounded-[40px] bg-gradient-to-b from-[#a5c8ff] via-[#cfe2ff] to-white p-10 shadow-[0_35px_120px_rgba(37,99,235,0.25)]">
+            <div className="h-64 rounded-3xl bg-white/80" />
+            <div className="mt-6 flex items-center justify-between text-sm text-slate-700">
+              <span>Letters Workspace</span>
+              <span className="font-semibold">Drag or select →</span>
+            </div>
+          </div>
+        </div>
+      </SectionWrapper>
+
+      <SectionWrapper className="pt-6">
+        <div className="text-center">
+          <p className="text-sm uppercase tracking-[0.4em] text-slate-500">Writing</p>
+          <h2 className="mt-4 text-4xl font-semibold">Writing <span className="text-blue-600">letters</span> has never been easier</h2>
+        </div>
+        <div className="mt-12 grid gap-8 md:grid-cols-2">
+          {writingCards.map((card) => (
+            <div key={card.title} className="rounded-[36px] bg-white p-8 shadow-[0_20px_70px_rgba(15,23,42,0.08)]">
+              <h3 className="text-2xl font-semibold text-slate-900">{card.title}</h3>
+              <p className="mt-4 text-slate-600">{card.description}</p>
+              <div className="mt-8 h-36 rounded-3xl" style={{ backgroundColor: card.accent }} />
+            </div>
+          ))}
+        </div>
+      </SectionWrapper>
+
+      <SectionWrapper className="pt-4">
+        <div className="rounded-[48px] bg-white p-12 text-center shadow-[0_25px_120px_rgba(15,23,42,0.08)]">
+          <p className="text-sm uppercase tracking-[0.5em] text-slate-500">Accuracy</p>
+          <h2 className="mt-5 text-4xl font-semibold">Gold-Standard Transcriptions</h2>
+          <p className="mt-3 text-lg text-slate-600 max-w-2xl mx-auto">
+            Extensive medical vocabulary & a custom dictionary to supercharge transcription accuracy.
+          </p>
+          <div className="mt-10 h-60 rounded-[40px] bg-gradient-to-b from-white via-[#f1f5ff] to-transparent" />
+        </div>
+      </SectionWrapper>
+
+      <SectionWrapper>
+        <div className="text-center">
+          <p className="text-sm uppercase tracking-[0.4em] text-slate-500">Onboarding</p>
+          <h2 className="mt-4 text-4xl font-semibold">Supercharge your Practice with Letters</h2>
+        </div>
+        <div className="mt-12 grid gap-8 md:grid-cols-3">
+          {practiceSteps.map((step, index) => (
+            <div key={step.title} className="rounded-[32px] bg-white p-8 shadow-[0_30px_90px_rgba(15,23,42,0.08)]">
+              <div className="h-10 w-10 rounded-full bg-blue-100 text-blue-600 flex items-center justify-center font-semibold mb-6">
+                {index + 1}
+              </div>
+              <h3 className="text-xl font-semibold">{step.title}</h3>
+              <p className="mt-4 text-slate-600">{step.description}</p>
+              <div className="mt-8 h-32 rounded-3xl bg-slate-100" />
+            </div>
+          ))}
+        </div>
+      </SectionWrapper>
+
+      <SectionWrapper className="pt-6">
+        <div className="rounded-[48px] bg-white/70 p-8 shadow-[0_25px_90px_rgba(15,23,42,0.08)]">
+          <div className="flex flex-col gap-6 lg:flex-row lg:items-stretch">
+            {testimonials.map((testimonial) => (
+              <div key={testimonial.name} className="rounded-[32px] bg-white p-8 flex flex-col justify-between">
+                <p className="text-slate-600">{testimonial.quote}</p>
+                <div className="mt-8">
+                  <p className="font-semibold">{testimonial.name}</p>
+                  <p className="text-sm text-slate-500">{testimonial.role}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </SectionWrapper>
+
+      <SectionWrapper>
+        <div className="text-center">
+          <p className="text-sm uppercase tracking-[0.4em] text-slate-500">Security</p>
+          <h2 className="mt-4 text-4xl font-semibold">Your data is safe</h2>
+        </div>
+        <div className="mt-12 grid gap-8 md:grid-cols-3">
+          {securityHighlights.map((highlight, index) => (
+            <div
+              key={highlight.title}
+              className={`rounded-[32px] bg-white p-8 text-center shadow-[0_30px_100px_rgba(15,23,42,0.08)] ${
+                index === 1 ? 'md:-mt-8 md:mb-8' : ''
+              }`}
+            >
+              <div className="h-20 w-20 mx-auto rounded-full bg-slate-100 flex items-center justify-center text-3xl">
+                {index === 1 ? '🛰️' : index === 2 ? '🔒' : '🛡️'}
+              </div>
+              <h3 className="mt-6 text-2xl font-semibold">{highlight.title}</h3>
+              <p className="mt-3 text-slate-600">{highlight.description}</p>
+            </div>
+          ))}
+        </div>
+      </SectionWrapper>
+
+      <section className="py-24 px-6">
+        <div className="max-w-6xl mx-auto rounded-[48px] bg-gradient-to-b from-[#b5d2ff] via-[#dce7ff] to-white p-12 shadow-[0_35px_150px_rgba(59,130,246,0.35)]">
+          <div className="text-center text-slate-900">
+            <p className="text-sm uppercase tracking-[0.4em] text-slate-600">Pricing</p>
+            <h2 className="mt-4 text-4xl font-semibold">Flexible pricing</h2>
+            <p className="mt-3 text-slate-700">Pick the plan that matches your practice.</p>
+            <div className="mt-6 inline-flex items-center rounded-full bg-white/70 p-1 text-sm font-semibold">
+              {['annual', 'monthly'].map((cycle) => (
+                <button
+                  key={cycle}
+                  type="button"
+                  onClick={() => setBillingCycle(cycle)}
+                  className={`px-6 py-2 rounded-full ${
+                    billingCycle === cycle ? 'bg-slate-900 text-white shadow' : 'text-slate-600'
+                  }`}
+                >
+                  {cycle === 'annual' ? 'Annual' : 'Monthly'}
+                </button>
+              ))}
+            </div>
+            <p className="mt-2 text-xs uppercase tracking-[0.5em] text-slate-600">{billingTag}</p>
+          </div>
+          <div className="mt-12 grid gap-8 md:grid-cols-3">
+            {pricingPlans.map((plan, index) => (
+              <div key={plan.name} className={`rounded-[36px] bg-white p-8 ${index === 1 ? 'shadow-[0_40px_120px_rgba(15,23,42,0.2)]' : 'shadow-[0_25px_90px_rgba(15,23,42,0.12)]'}`}>
+                <p className="text-sm font-semibold text-slate-500">{plan.name}</p>
+                <p className="mt-4 text-4xl font-semibold">{plan.price}</p>
+                <p className="mt-2 text-slate-600">{plan.description}</p>
+                <ul className="mt-6 space-y-3 text-sm text-slate-600">
+                  {plan.features.map((feature) => (
+                    <li key={feature} className="flex items-center space-x-2">
+                      <span className="h-2 w-2 rounded-full bg-slate-900" />
+                      <span>{feature}</span>
+                    </li>
+                  ))}
+                </ul>
+                <button
+                  type="button"
+                  className={`mt-8 w-full rounded-full px-6 py-3 text-sm font-semibold ${
+                    index === 1 ? 'bg-slate-900 text-white' : 'bg-slate-100 text-slate-900'
+                  }`}
+                >
+                  {plan.cta}
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <SectionWrapper>
+        <div className="text-center">
+          <p className="text-sm uppercase tracking-[0.4em] text-slate-500">Devices</p>
+          <h2 className="mt-4 text-4xl font-semibold">Letters works seamlessly across all your devices</h2>
+          <p className="mt-3 text-lg text-slate-600 max-w-2xl mx-auto">
+            Whether you are on web, iPad or iOS — start on one device, pick up on another. Letters stays perfectly in sync.
+          </p>
+        </div>
+        <div className="mt-12 grid gap-8 md:grid-cols-3">
+          {deviceCards.map((card) => (
+            <div key={card.title} className="rounded-[32px] bg-white p-8 text-center shadow-[0_25px_80px_rgba(15,23,42,0.08)]">
+              <div className="mx-auto h-36 w-full rounded-3xl bg-slate-100" />
+              <h3 className="mt-6 text-xl font-semibold">{card.title}</h3>
+              <p className="mt-3 text-slate-600">{card.description}</p>
+            </div>
+          ))}
+        </div>
+        <div className="mt-12 text-center">
+          <button type="button" className="rounded-full bg-slate-900 px-8 py-3 text-white text-sm font-semibold">
+            Sign up for free
+          </button>
+        </div>
+      </SectionWrapper>
     </div>
   );
 }

--- a/wisdom-web/src/components/SkyStars.jsx
+++ b/wisdom-web/src/components/SkyStars.jsx
@@ -1,0 +1,62 @@
+import { useEffect, useRef } from 'react';
+import * as THREE from 'three';
+
+const SkyStars = () => {
+  const mountRef = useRef(null);
+
+  useEffect(() => {
+    if (!mountRef.current) return;
+
+    const { clientWidth, clientHeight } = mountRef.current;
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(60, clientWidth / clientHeight, 0.1, 1000);
+    camera.position.z = 5;
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+    renderer.setSize(clientWidth, clientHeight);
+    renderer.setPixelRatio(window.devicePixelRatio);
+    mountRef.current.appendChild(renderer.domElement);
+
+    const starsGeometry = new THREE.BufferGeometry();
+    const starCount = 220;
+    const positions = new Float32Array(starCount * 3);
+
+    for (let i = 0; i < starCount; i += 1) {
+      positions[i * 3] = (Math.random() - 0.5) * 10;
+      positions[i * 3 + 1] = (Math.random() - 0.5) * 6;
+      positions[i * 3 + 2] = Math.random() * -5;
+    }
+
+    starsGeometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    const starsMaterial = new THREE.PointsMaterial({ color: 0xffffff, size: 0.02 });
+    const stars = new THREE.Points(starsGeometry, starsMaterial);
+    scene.add(stars);
+
+    renderer.render(scene, camera);
+
+    const handleResize = () => {
+      if (!mountRef.current) return;
+      const { clientWidth: newWidth, clientHeight: newHeight } = mountRef.current;
+      renderer.setSize(newWidth, newHeight);
+      camera.aspect = newWidth / newHeight;
+      camera.updateProjectionMatrix();
+      renderer.render(scene, camera);
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+      starsGeometry.dispose();
+      starsMaterial.dispose();
+      renderer.dispose();
+      if (mountRef.current?.firstChild) {
+        mountRef.current.removeChild(renderer.domElement);
+      }
+    };
+  }, []);
+
+  return <div ref={mountRef} className="absolute inset-0 pointer-events-none" aria-hidden />;
+};
+
+export default SkyStars;

--- a/wisdom-web/src/index.css
+++ b/wisdom-web/src/index.css
@@ -1,73 +1,27 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
-/* Tu CSS personalizado */
 :root {
-  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
+  font-family: 'Inter', sans-serif;
+  color: #0f172a;
+  background-color: #f8fafc;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
+* {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
   min-height: 100vh;
+  background-color: #f8fafc;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+#root {
+  min-height: 100vh;
 }

--- a/wisdom-web/tailwind.config.js
+++ b/wisdom-web/tailwind.config.js
@@ -6,6 +6,9 @@ export default {
   ],
   theme: {
     extend: {
+      fontFamily: {
+        inter: ['Inter', 'sans-serif'],
+      },
       keyframes: {
         slide: {
           '0%': { transform: 'translateX(100%)' },


### PR DESCRIPTION
## Summary
- rebuild the homepage to match the Letters mockups with dedicated hero, workflow, testimonials, pricing, and device sections
- add a reusable SectionWrapper layout, workflow tabs, pricing toggles, and placeholder illustration blocks using TailwindCSS utilities and Inter font
- introduce a static Three.js starfield background component and update Tailwind configuration for the Inter font family

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919a58303fc832ba6a1ce4d8c340bfe)